### PR TITLE
make random_state sklearn compliant

### DIFF
--- a/.github/workflows/sonarqube_build.yml
+++ b/.github/workflows/sonarqube_build.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -60,8 +60,14 @@ jobs:
           chmod +x codecov
           ./codecov
 
-      - name: Setup sonarqube
-        uses: warchant/setup-sonar-scanner@v3
+      - name: Setup Java
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup SonarQube
+        uses: warchant/setup-sonar-scanner@v7
 
       - name: Sonarqube coverage
         run: |

--- a/.github/workflows/sonarqube_build.yml
+++ b/.github/workflows/sonarqube_build.yml
@@ -77,8 +77,8 @@ jobs:
         run: sonar-scanner
           -Dsonar.host.url=https://sonarcloud.io/
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-          -Dsonar.projectKey=rpreen_xcsf
-          -Dsonar.organization=rpreen
+          -Dsonar.projectKey=xcsf-dev_xcsf
+          -Dsonar.organization=xcsf-dev
           -Dsonar.projectVersion=1.0
           -Dsonar.projectBaseDir=./
           -Dsonar.cfamily.build-wrapper-output=build/bw-output

--- a/.github/workflows/sonarqube_build.yml
+++ b/.github/workflows/sonarqube_build.yml
@@ -61,7 +61,7 @@ jobs:
           ./codecov
 
       - name: Setup Java
-      - uses: actions/setup-java@v3
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the project [wiki](https://github.com/xcsf-dev/xcsf/wiki) for details on fea
 
 [![Codacy](https://img.shields.io/codacy/grade/2213b9ad4e034482bf058d4598d1618b?logo=codacy&style=flat)](https://app.codacy.com/gh/rpreen/xcsf/dashboard)
 [![CodeFactor](https://img.shields.io/codefactor/grade/github/xcsf-dev/xcsf?logo=codefactor&style=flat)](https://www.codefactor.io/repository/github/xcsf-dev/xcsf)
-[![SonarCloud](https://sonarcloud.io/api/project_badges/measure?project=rpreen_xcsf&metric=alert_status)](https://sonarcloud.io/dashboard?id=rpreen_xcsf)
+[![SonarCloud](https://sonarcloud.io/api/project_badges/measure?project=xcsf-dev_xcsf&metric=alert_status)](https://sonarcloud.io/dashboard?id=xcsf-dev_xcsf)
 [![codecov](https://codecov.io/gh/xcsf-dev/xcsf/branch/master/graph/badge.svg?token=3bfaTvmJ8d)](https://codecov.io/gh/xcsf-dev/xcsf)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=rpreen_xcsf&metric=ncloc)](https://sonarcloud.io/dashboard?id=rpreen_xcsf)
 

--- a/cfg/default.json
+++ b/cfg/default.json
@@ -1,6 +1,6 @@
 {
     "omp_num_threads": 8,
-    "random_state": 0,
+    "random_state": -1,
     "pop_init": true,
     "max_trials": 100000,
     "perf_trials": 1000,

--- a/xcsf/param.c
+++ b/xcsf/param.c
@@ -60,7 +60,7 @@ param_init(struct XCSF *xcsf, const int x_dim, const int y_dim,
     param_set_x_dim(xcsf, x_dim);
     param_set_y_dim(xcsf, y_dim);
     param_set_omp_num_threads(xcsf, 8);
-    param_set_random_state(xcsf, 0);
+    param_set_random_state(xcsf, -1);
     param_set_pop_init(xcsf, true);
     param_set_max_trials(xcsf, 100000);
     param_set_perf_trials(xcsf, 1000);
@@ -608,10 +608,10 @@ const char *
 param_set_random_state(struct XCSF *xcsf, const int a)
 {
     xcsf->RANDOM_STATE = a;
-    if (a > 0) {
-        rand_init_seed(a);
-    } else {
+    if (a < 0) {
         rand_init();
+    } else {
+        rand_init_seed(a);
     }
     return NULL;
 }


### PR DESCRIPTION
Currently `random_state` can only be an integer value where `<= 0` uses the system time and `> 0` sets the seed.

This PR makes Python library `random_state` sklearn compliant:

* `random_state` with an integer value `< 0` uses system time as seed;
* `random_state` with an integer value `>= 0` will set the seed;
* Python API maps `random_state = None` to `-1` and uses system time as seed;

**Note** that are still some situations where setting the random number seed will not result in reproducible results, such as when using parallel processing and random numbers are used during forward propagation of neural nets (such as dropout layers.)