### PR TITLE
add extra defensive checks

### DIFF
--- a/.github/workflows/sonarqube_build.yml
+++ b/.github/workflows/sonarqube_build.yml
@@ -76,16 +76,17 @@ jobs:
       - name: Run sonarqube
         run: sonar-scanner
           -Dsonar.host.url=https://sonarcloud.io/
-          -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+          -Dsonar.token=${{ secrets.SONAR_TOKEN }}
           -Dsonar.projectKey=xcsf-dev_xcsf
           -Dsonar.organization=xcsf-dev
           -Dsonar.projectVersion=1.0
           -Dsonar.projectBaseDir=./
           -Dsonar.cfamily.build-wrapper-output=build/bw-output
-          -Dsonar.cfamily.cache.enabled=false
+          -Dsonar.cfamily.analysisCache.mode=server
           -Dsonar.cfamily.threads=1
           -Dsonar.coverage.exclusions="python/**,test/**,lib/**,doc/**"
           -Dsonar.exclusions="python/**,test/**,lib/**,doc/**"
           -Dsonar.sourceEncoding=UTF-8
           -Dsonar.coverageReportPaths=coverage.xml
+          -Dsonar.python.version=3.11
 ...

--- a/xcsf/clset.c
+++ b/xcsf/clset.c
@@ -65,13 +65,13 @@ static void
 clset_pset_roulette(const struct XCSF *xcsf, struct Clist **del,
                     struct Clist **delprev)
 {
-    struct Clist *iter = xcsf->pset.list;
-    if (iter == NULL) {
+    if (xcsf->pset.list == NULL) {
         printf("clset_pset_roulette(): error pset is empty\n");
         exit(EXIT_FAILURE);
     }
     const double avg_fit = clset_total_fit(&xcsf->pset) / xcsf->pset.num;
     double total_vote = 0;
+    struct Clist *iter = xcsf->pset.list;
     while (iter != NULL) {
         total_vote += cl_del_vote(xcsf, iter->cl, avg_fit);
         iter = iter->next;
@@ -359,6 +359,10 @@ clset_pset_enforce_limit(struct XCSF *xcsf)
 void
 clset_match(struct XCSF *xcsf, const double *x, const bool cover)
 {
+    if (xcsf->pset.list == NULL) {
+        printf("clset_match(): error pset is empty\n");
+        exit(EXIT_FAILURE);
+    }
 #ifdef PARALLEL_MATCH
     // prepare for parallel processing of matching conditions
     struct Clist *blist[xcsf->pset.size];
@@ -452,6 +456,10 @@ void
 clset_update(struct XCSF *xcsf, struct Set *set, const double *x,
              const double *y, const bool cur)
 {
+    if (set->list == NULL) {
+        printf("clset_update(): error set is empty\n");
+        exit(EXIT_FAILURE);
+    }
 #ifdef PARALLEL_UPDATE
     struct Clist *blist[set->size];
     struct Clist *iter = set->list;

--- a/xcsf/clset.c
+++ b/xcsf/clset.c
@@ -65,9 +65,13 @@ static void
 clset_pset_roulette(const struct XCSF *xcsf, struct Clist **del,
                     struct Clist **delprev)
 {
+    struct Clist *iter = xcsf->pset.list;
+    if (iter == NULL) {
+        printf("clset_pset_roulette(): error pset is empty\n");
+        exit(EXIT_FAILURE);
+    }
     const double avg_fit = clset_total_fit(&xcsf->pset) / xcsf->pset.num;
     double total_vote = 0;
-    struct Clist *iter = xcsf->pset.list;
     while (iter != NULL) {
         total_vote += cl_del_vote(xcsf, iter->cl, avg_fit);
         iter = iter->next;


### PR DESCRIPTION
Adds extra checks for empty sets before performing operations such as roulette wheel deletion, match set building and set updating -- these should never happen in practice and would segfault if it did --- if this ever does somehow happen, this will gracefully exit with a message; and tries to satisfy the static analysis tools.