### PR TITLE
add Python tests

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -43,6 +43,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DXCSF_PYLIB=ON
           -DENABLE_TESTS=ON
+          -DPYTEST=ON
 
       - name: Build
         working-directory: build

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -43,6 +43,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DXCSF_PYLIB=ON
           -DENABLE_TESTS=ON
+          -DPYTEST=ON
 
       - name: Build
         working-directory: build

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -51,6 +51,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DXCSF_PYLIB=ON
           -DENABLE_TESTS=ON
+          -DPYTEST=ON
           -G "MinGW Makefiles"
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.log
 *.o
 *.opensdf
+*.pyc
 *.pyd
 *.rar
 *.sdf

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.log
 *.o
 *.opensdf
+*.pkl
 *.pyc
 *.pyd
 *.rar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Changes:
 *   Fix saving and loading DGP graphs from persistent storage ([#151](https://github.com/xcsf-dev/xcsf/pull/151))
+*   Add Python tests ([#149](https://github.com/xcsf-dev/xcsf/pull/149))
 
 ## Version 1.4.6 (Jul 21, 2024)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ if(XCSF_PYLIB)
   file(COPY "xcsf/__init__.py" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/xcsf/)
   if(PYTEST)
     # Copy the Python tests
-    file(COPY "python/test/test_xcsf.py" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    file(COPY "test/python/test_xcsf.py" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
     # Execute pip to install test dependencies
     execute_process(
         COMMAND "${PYTHON_EXECUTABLE}" -m pip install pytest numpy scikit-learn

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,8 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 option(XCSF_MAIN "Build XCSF stand-alone main executable" ON)
 option(XCSF_PYLIB "Build XCSF Python library" OFF)
 option(PARALLEL "Parallel match set and prediction" ON)
-option(ENABLE_TESTS "Build unit tests" OFF)
+option(ENABLE_TESTS "Build standard unit tests" OFF)
+option(PYTEST "Build Python tests" OFF)
 option(NATIVE_OPT "Optimise for the native architecture" ON)
 option(ENABLE_DOXYGEN "Enable Building XCSF Documentation" ON)
 option(GEN_PROF "Generate profiling information" OFF)
@@ -174,6 +175,22 @@ if(XCSF_PYLIB)
   file(COPY ${PYTHON_EXAMPLES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
   file(COPY "xcsf/utils/" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/xcsf/utils/)
   file(COPY "xcsf/__init__.py" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/xcsf/)
+  if(PYTEST)
+    # Copy the Python tests
+    file(COPY "python/test/test_xcsf.py" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    # Execute pip to install test dependencies
+    execute_process(
+        COMMAND "${PYTHON_EXECUTABLE}" -m pip install pytest numpy scikit-learn
+    )
+    # Add pytest
+    add_test(NAME pytest COMMAND "${PYTHON_EXECUTABLE} -m pytest .")
+    add_custom_target(run_tests ALL
+        COMMAND pytest
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Running pytest..."
+    )
+    add_dependencies(run_tests xcsf)
+  endif()
 endif()
 
 if(ENABLE_DOXYGEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,18 +177,30 @@ if(XCSF_PYLIB)
   file(COPY "xcsf/__init__.py" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/xcsf/)
   if(PYTEST)
     # Copy the Python tests
-    file(COPY "test/python/test_xcsf.py" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-    # Execute pip to install test dependencies
+    file(GLOB PYTHON_TESTS "test/python/*.py")
+    file(COPY ${PYTHON_TESTS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    # Create a virtual environment
+    set(VENV_DIR "${CMAKE_CURRENT_BINARY_DIR}/venv")
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" -m venv "${VENV_DIR}")
+    # Activate the virtual environment
+    if(WIN32)
+      set(PYTHON_EXEC "${VENV_DIR}/Scripts/python")
+    else()
+      set(PYTHON_EXEC "${VENV_DIR}/bin/python")
+    endif()
+    # Install dependencies
     execute_process(
-        COMMAND "${PYTHON_EXECUTABLE}" -m pip install pytest numpy scikit-learn
+      COMMAND "${PYTHON_EXEC}" -m pip install pytest numpy scikit-learn
     )
-    # Add pytest
-    add_test(NAME pytest COMMAND "${PYTHON_EXECUTABLE} -m pytest .")
+    # Add pytest to ctest (to capture CI failures)
+    add_test(NAME pytest COMMAND "${PYTHON_EXEC}" -m pytest .)
+    # Execute pytest at the end of building
     add_custom_target(run_tests ALL
-        COMMAND pytest
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMENT "Running pytest..."
+      COMMAND "${PYTHON_EXEC}" -m pytest .
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      COMMENT "Running pytest..."
     )
+    # Wait for XCSF to be built
     add_dependencies(run_tests xcsf)
   endif()
 endif()

--- a/python/test/test_xcsf.py
+++ b/python/test/test_xcsf.py
@@ -1,0 +1,175 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2024 Richard Preen <rpreen@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""XCSF Python tests."""
+
+from __future__ import annotations
+
+from collections import namedtuple
+
+import pickle
+import numpy as np
+import pytest
+from sklearn.datasets import fetch_openml
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+import xcsf
+
+# pylint: disable=redefined-outer-name,invalid-name
+
+PATH: str = "RES_PYTEST"
+SEED: int = 101
+
+Data = namedtuple(
+    "Data",
+    ["x_dim", "y_dim", "x_train", "y_train", "x_val", "y_val", "x_test", "y_test"],
+)
+
+
+@pytest.fixture
+def data() -> Data:
+    """Load test data."""
+    df = fetch_openml(data_id=189, as_frame=True, parser="auto")
+    x = np.asarray(df.data, dtype=np.float64)
+    y = np.asarray(df.target, dtype=np.float64)
+
+    feature_scaler = StandardScaler()
+    x = feature_scaler.fit_transform(x)
+    if y.ndim == 1:
+        y = y.reshape(-1, 1)
+
+    output_scaler = StandardScaler()
+    y = output_scaler.fit_transform(y)
+
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, test_size=0.1, random_state=SEED
+    )
+
+    x_train, x_val, y_train, y_val = train_test_split(
+        x_train, y_train, test_size=0.1, random_state=SEED
+    )
+
+    return Data(
+        np.shape(x_train)[1],
+        np.shape(y_train)[1],
+        x_train,
+        y_train,
+        x_val,
+        y_val,
+        x_test,
+        y_test,
+    )
+
+
+@pytest.mark.parametrize(
+    "prediction",
+    [
+        {"type": "constant"},
+        {"type": "nlms_linear"},
+        {"type": "nlms_quadratic"},
+        {"type": "rls_linear"},
+        {"type": "rls_quadratic"},
+        {"type": "neural"},
+    ],
+)
+def test_deterministic_prediction(data, prediction):
+    """Test deterministic prediction."""
+    xcs = xcsf.XCS(
+        x_dim=data.x_dim,
+        y_dim=data.y_dim,
+        pop_size=200,
+        max_trials=1000,
+        random_state=SEED,
+        prediction=prediction,
+    )
+    xcs.fit(data.x_train, data.y_train)
+    a: np.ndarray = xcs.predict(data.x_test)
+    b: np.ndarray = xcs.predict(data.x_test)
+    assert np.all(a == b)
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        {"type": "dummy"},
+        {"type": "ternary"},
+        {"type": "hyperrectangle_ubr"},
+        {"type": "hyperrectangle_csr"},
+        {"type": "hyperellipsoid"},
+        {"type": "neural"},
+        {"type": "tree_gp"},
+        {"type": "dgp"},
+    ],
+)
+@pytest.mark.parametrize(
+    "prediction",
+    [
+        {"type": "constant"},
+        {"type": "nlms_linear"},
+        {"type": "nlms_quadratic"},
+        {"type": "rls_linear"},
+        {"type": "rls_quadratic"},
+        {"type": "neural"},
+    ],
+)
+def test_saving(data, condition, prediction):
+    """Test saving and loading.
+
+    Note:
+    -----
+    Calling `predict()` will modify internal parameters such as the current
+    prediction, matching state, etc., so we have make sure to perform
+    comparisons before modification.
+    """
+    # create model
+    xcs1 = xcsf.XCS(
+        x_dim=data.x_dim,
+        y_dim=data.y_dim,
+        pop_size=20,
+        max_trials=100,
+        random_state=SEED,
+        condition=condition,
+        prediction=prediction,
+    )
+
+    # fit model
+    xcs1.fit(data.x_train, data.y_train)
+
+    # save with pickle
+    with open("blah.pkl", "wb") as fp:
+        pickle.dump(xcs1, fp)
+
+    # load from pickle
+    with open("blah.pkl", "rb") as fp:
+        xcs2 = pickle.load(fp)
+
+    # compare parameters
+    orig_params: dict = xcs1.internal_params()
+    new_params: dict = xcs2.internal_params()
+    assert orig_params == new_params
+
+    # compare populations
+    orig_pop: str = xcs1.json()
+    new_pop: str = xcs2.json()
+    assert orig_pop == new_pop
+
+    # compare predictions
+    orig_pred: np.ndarray = xcs1.predict(data.x_test)
+    new_pred: np.ndarray = xcs2.predict(data.x_test)
+    assert np.all(orig_pred == new_pred)

--- a/test/python/test_xcsf.py
+++ b/test/python/test_xcsf.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from collections import namedtuple
 
+import json
 import os
 import pickle
 import numpy as np
@@ -34,11 +35,14 @@ import xcsf
 
 SEED: int = 101
 PKL_FILENAME: str = "blah.pkl"
+POP_FILENAME: str = "pset.json"
 
 Data = namedtuple(
     "Data",
     ["x_dim", "y_dim", "x_train", "y_train", "x_val", "y_val", "x_test", "y_test"],
 )
+
+np.random.seed(SEED)
 
 
 @pytest.fixture(scope="module")
@@ -80,7 +84,26 @@ def data() -> Data:
     )
 
 
-def predictions():
+def dicts_equal(d1: dict, d2: dict) -> bool:
+    """Return whether all items in d1 are present and equal in d2.
+
+    Recursively checks if all items in the first dictionary (d1) are present and
+    equal to the corresponding items in the second dictionary (d2). This function
+    also handles nested dictionaries.
+    """
+    for key, value in d1.items():
+        if key not in d2:
+            return False
+        if isinstance(value, dict):
+            if not isinstance(d2[key], dict) or not dicts_equal(value, d2[key]):
+                return False
+        else:
+            if d2[key] != value:
+                return False
+    return True
+
+
+def predictions() -> list[dict]:
     """Return list of prediction args."""
     return [
         {"type": "constant"},
@@ -92,7 +115,7 @@ def predictions():
     ]
 
 
-def conditions():
+def conditions() -> list[dict]:
     """Return list of condition args."""
     return [
         {"type": "dummy"},
@@ -142,7 +165,7 @@ def test_serialization(data, condition, prediction):
     Note:
     -----
     Calling `predict()` will modify internal parameters such as the current
-    prediction, matching state, etc., so we have to make sure to perform
+    prediction, matching state, etc., so we have make sure to perform
     comparisons before modification.
     """
     # create model
@@ -189,3 +212,80 @@ def test_serialization(data, condition, prediction):
     # clean up
     if os.path.exists(PKL_FILENAME):
         os.remove(PKL_FILENAME)
+
+
+def test_seeding(data):
+    """Test population seeding.
+
+    Currently only tests hyperrectangle ubr.
+    """
+    # create human-designed classifier
+    classifier: dict = {
+        "error": 0.05,
+        "fitness": 0.3,
+        "set_size": 100,
+        "numerosity": 2,
+        "experience": 3,
+        "time": 3,
+        "samples_seen": 2,
+        "samples_matched": 1,
+        "condition": {
+            "type": "hyperrectangle_ubr",
+            "bound1": np.round(np.random.rand(data.x_dim), 10).tolist(),
+            "bound2": np.round(np.random.rand(data.x_dim), 10).tolist(),
+            "mutation": [0.2],
+        },
+    }
+
+    # write population set file
+    with open(POP_FILENAME, "w", encoding="utf-8") as file:
+        pset = {"classifiers": [classifier]}
+        json.dump(pset, file)
+
+    # create model with initial population set from a file
+    xcs = xcsf.XCS(
+        x_dim=data.x_dim,
+        y_dim=data.y_dim,
+        n_actions=1,
+        random_state=SEED,
+        population_file=POP_FILENAME,
+        max_trials=1,
+        pop_init=False,
+        action={"type": "integer"},
+        condition={"type": "hyperrectangle_ubr"},
+        prediction={"type": "nlms_linear"},
+    )
+
+    # add human-designed classifier again, this time manually
+    clj: str = json.dumps(classifier)  # dictionary to JSON
+    xcs.json_insert_cl(clj)
+
+    # get current population
+    pop: list[dict] = json.loads(xcs.json())["classifiers"]
+
+    # check two classifiers are present
+    assert len(pop) == 2
+
+    # check population has been seeded correctly
+    for cl in pop:
+        assert dicts_equal(classifier, cl)
+
+    # fit a single sample
+    X1 = data.x_train[0].reshape(1, -1)
+    y1 = data.y_train[0].reshape(1, -1)
+    xcs.fit(X1, y1, warm_start=True)
+
+    # get updated population
+    new_pop: list[dict] = json.loads(xcs.json())["classifiers"]
+
+    # check an additional classifier has been added via covering
+    assert len(new_pop) == 3
+
+    # check conditions are still present
+    classifier = {k: classifier[k] for k in ["condition"] if k in classifier}
+    for cl in new_pop[1:]:  # skip first (covered) classifier
+        assert dicts_equal(classifier, cl)
+
+    # clean up
+    if os.path.exists(POP_FILENAME):
+        os.remove(POP_FILENAME)

--- a/test/python/test_xcsf.py
+++ b/test/python/test_xcsf.py
@@ -77,17 +77,33 @@ def data() -> Data:
     )
 
 
-@pytest.mark.parametrize(
-    "prediction",
-    [
+def predictions():
+    """Return list of prediction args."""
+    return [
         {"type": "constant"},
         {"type": "nlms_linear"},
         {"type": "nlms_quadratic"},
         {"type": "rls_linear"},
         {"type": "rls_quadratic"},
         {"type": "neural"},
-    ],
-)
+    ]
+
+
+def conditions():
+    """Return list of condition args."""
+    return [
+        {"type": "dummy"},
+        {"type": "ternary"},
+        {"type": "hyperrectangle_ubr"},
+        {"type": "hyperrectangle_csr"},
+        {"type": "hyperellipsoid"},
+        {"type": "neural"},
+        {"type": "tree_gp"},
+        {"type": "dgp"},
+    ]
+
+
+@pytest.mark.parametrize("prediction", predictions())
 def test_deterministic_prediction(data, prediction):
     """Test deterministic prediction."""
     xcs = xcsf.XCS(
@@ -104,30 +120,8 @@ def test_deterministic_prediction(data, prediction):
     assert np.all(a == b)
 
 
-@pytest.mark.parametrize(
-    "condition",
-    [
-        {"type": "dummy"},
-        {"type": "ternary"},
-        {"type": "hyperrectangle_ubr"},
-        {"type": "hyperrectangle_csr"},
-        {"type": "hyperellipsoid"},
-        {"type": "neural"},
-        {"type": "tree_gp"},
-        {"type": "dgp"},
-    ],
-)
-@pytest.mark.parametrize(
-    "prediction",
-    [
-        {"type": "constant"},
-        {"type": "nlms_linear"},
-        {"type": "nlms_quadratic"},
-        {"type": "rls_linear"},
-        {"type": "rls_quadratic"},
-        {"type": "neural"},
-    ],
-)
+@pytest.mark.parametrize("condition", conditions())
+@pytest.mark.parametrize("prediction", predictions())
 def test_saving(data, condition, prediction):
     """Test saving and loading.
 

--- a/xcsf/clset.c
+++ b/xcsf/clset.c
@@ -621,6 +621,25 @@ clset_pset_save(const struct XCSF *xcsf, FILE *fp)
 }
 
 /**
+ * @brief Reverses the order of the population classifier list.
+ * @param [in] xcsf The XCSF data structure.
+ */
+static void
+clset_pset_reverse(struct XCSF *xcsf)
+{
+    struct Clist *current = xcsf->pset.list;
+    struct Clist *prev = NULL;
+    struct Clist *next = NULL;
+    while (current != NULL) {
+        next = current->next;
+        current->next = prev;
+        prev = current;
+        current = next;
+    }
+    xcsf->pset.list = prev;
+}
+
+/**
  * @brief Reads the population set from a file.
  * @param [in] xcsf The XCSF data structure.
  * @param [in] fp Pointer to the file to be read.
@@ -640,6 +659,7 @@ clset_pset_load(struct XCSF *xcsf, FILE *fp)
         s += cl_load(xcsf, c, fp);
         clset_add(&xcsf->pset, c);
     }
+    clset_pset_reverse(xcsf); // reverse population list for consistency
     return s;
 }
 


### PR DESCRIPTION
This PR adds the option to build and execute Python tests using pytest with CMake option: `-DPYTEST=ON`

* Tests are added to `test/python/test_xcsf.py`
* It automatically executes pip to install the required `pytest numpy scikit-learn` and runs `pytest .` upon building
* The population set linked list is reversed upon loading for consistency, e.g., reproducible predictions.