### PR TITLE
Fix `json_read` crashing when the new population is empty

### DIFF
--- a/test/python/test_xcsf.py
+++ b/test/python/test_xcsf.py
@@ -380,9 +380,9 @@ def test_pop_replace(
 ):
     for seed in range(19):
         np.random.seed(seed)
-        assert _test_pop_replace(
-            tmp_path, pop_init, clean, fitinbetween, warm_start
-        ), f"failed at seed {seed}"
+        assert _test_pop_replace(tmp_path, pop_init, clean, fitinbetween, warm_start), (
+            f"failed at seed {seed}"
+        )
 
 
 def test_pop_replace_empty(tmp_path):

--- a/test/python/test_xcsf.py
+++ b/test/python/test_xcsf.py
@@ -380,6 +380,47 @@ def test_pop_replace(
 ):
     for seed in range(19):
         np.random.seed(seed)
-        assert _test_pop_replace(tmp_path, pop_init, clean, fitinbetween, warm_start), (
-            f"failed at seed {seed}"
-        )
+        assert _test_pop_replace(
+            tmp_path, pop_init, clean, fitinbetween, warm_start
+        ), f"failed at seed {seed}"
+
+
+def test_pop_replace_empty(tmp_path):
+    # Init'ing the pop and overwriting it with an empty one using the clean
+    # option should result in an empty pop.
+    xcs = xcsf.XCS(pop_size=100, max_trials=1000, pop_init=True)
+
+    assert xcs.pset_size() == 100
+
+    jsonpop = {"classifiers": []}
+    fpath = tmp_path / "pset1.json"
+    fpath.write_text(json.dumps(jsonpop))
+    xcs.json_read(str(fpath), clean=True)
+
+    assert xcs.pset_size() == 0
+
+    # Not init'ing the pop and overwriting it with an empty one using the clean
+    # option should keep the pop empty.
+    xcs = xcsf.XCS(pop_size=100, max_trials=1000, pop_init=False)
+
+    assert xcs.pset_size() == 0
+
+    jsonpop = {"classifiers": []}
+    fpath = tmp_path / "pset1.json"
+    fpath.write_text(json.dumps(jsonpop))
+    xcs.json_read(str(fpath), clean=True)
+
+    assert xcs.pset_size() == 0
+
+    # Init'ing the pop and overwriting it with an empty one but without using
+    # the clean option should not empty the pop.
+    xcs = xcsf.XCS(pop_size=100, max_trials=1000, pop_init=True)
+
+    assert xcs.pset_size() == 100
+
+    jsonpop = {"classifiers": []}
+    fpath = tmp_path / "pset1.json"
+    fpath.write_text(json.dumps(jsonpop))
+    xcs.json_read(str(fpath), clean=False)
+
+    assert xcs.pset_size() == 100

--- a/xcsf/clset.c
+++ b/xcsf/clset.c
@@ -799,13 +799,15 @@ clset_json_insert(struct XCSF *xcsf, const char *json_str)
     utils_json_parse_check(json);
     if (json->child != NULL && cJSON_IsArray(json->child)) {
         cJSON *tail = json->child->child; // insert inverted for consistency
-        tail->prev = NULL; // this should have been set by cJSON!
-        while (tail->next != NULL) {
-            tail = tail->next;
-        }
-        while (tail != NULL) {
-            clset_json_insert_cl(xcsf, tail);
-            tail = tail->prev;
+        if (tail != NULL) {
+            tail->prev = NULL; // this should have been set by cJSON!
+            while (tail->next != NULL) {
+                tail = tail->next;
+            }
+            while (tail != NULL) {
+                clset_json_insert_cl(xcsf, tail);
+                tail = tail->prev;
+            }
         }
     }
     cJSON_Delete(json);


### PR DESCRIPTION
I.e. when the JSON file only contains `{ "classifiers" : [] }`. This so far always resulted in a segfault which can't be desired.