### PR TITLE
Reduce `max_trials` in Python tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes:
 *   Add `clean` parameter to wipe existing population to `json_read` ([#202](https://github.com/xcsf-dev/xcsf/pull/202))
 *   Add Ruff linting and formatting for Python ([#196](https://github.com/xcsf-dev/xcsf/pull/196))
 *   Fix Python `json_read` crashing when the new population is empty ([#205](https://github.com/xcsf-dev/xcsf/pull/205))
+*   Reduce `max_trials` in Python tests for speed
 
 ## Version 1.4.7 (Aug 19, 2024)
 

--- a/test/python/test_xcsf.py
+++ b/test/python/test_xcsf.py
@@ -139,7 +139,7 @@ def test_deterministic_prediction(data, prediction):
         y_dim=data.y_dim,
         n_actions=1,
         pop_size=200,
-        max_trials=1000,
+        max_trials=100,
         random_state=SEED,
         prediction=prediction,
     )
@@ -329,7 +329,7 @@ def _test_pop_replace(
     X = np.random.random((n, dx))
     y = np.random.randn(n, 1)
 
-    xcs = xcsf.XCS(x_dim=dx, pop_size=5, max_trials=1000, pop_init=pop_init)
+    xcs = xcsf.XCS(x_dim=dx, pop_size=5, max_trials=100, pop_init=pop_init)
     xcs.fit(X, y, verbose=False)
 
     # Initial, “too large” population.
@@ -388,7 +388,7 @@ def test_pop_replace(
 def test_pop_replace_empty(tmp_path):
     # Init'ing the pop and overwriting it with an empty one using the clean
     # option should result in an empty pop.
-    xcs = xcsf.XCS(pop_size=100, max_trials=1000, pop_init=True)
+    xcs = xcsf.XCS(pop_size=100, max_trials=100, pop_init=True)
 
     assert xcs.pset_size() == 100
 
@@ -401,7 +401,7 @@ def test_pop_replace_empty(tmp_path):
 
     # Not init'ing the pop and overwriting it with an empty one using the clean
     # option should keep the pop empty.
-    xcs = xcsf.XCS(pop_size=100, max_trials=1000, pop_init=False)
+    xcs = xcsf.XCS(pop_size=100, max_trials=100, pop_init=False)
 
     assert xcs.pset_size() == 0
 
@@ -414,7 +414,7 @@ def test_pop_replace_empty(tmp_path):
 
     # Init'ing the pop and overwriting it with an empty one but without using
     # the clean option should not empty the pop.
-    xcs = xcsf.XCS(pop_size=100, max_trials=1000, pop_init=True)
+    xcs = xcsf.XCS(pop_size=100, max_trials=100, pop_init=True)
 
     assert xcs.pset_size() == 100
 


### PR DESCRIPTION
@rpreen said in the comments on #205 that testing with `max_trials=100` should suffice (and I think so, too). This speeds up the Python tests.