### PR TITLE
update wheel builder

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           submodules: true
 
-      - name: Install OpenMP
+      - name: Install Dependencies
         run: |
-          brew install libomp
+          brew install gcc libomp libgf2x
           OPENMP_PREFIX=$(brew --prefix)/opt/libomp
           echo "OpenMP_ROOT=$OPENMP_PREFIX" >> $GITHUB_ENV
           echo "LDFLAGS=$LDFLAGS -L$OPENMP_PREFIX/lib" >> $GITHUB_ENV

--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          brew install gcc libomp libgf2x
+          brew install libomp
           OPENMP_PREFIX=$(brew --prefix)/opt/libomp
           echo "OpenMP_ROOT=$OPENMP_PREFIX" >> $GITHUB_ENV
           echo "LDFLAGS=$LDFLAGS -L$OPENMP_PREFIX/lib" >> $GITHUB_ENV

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,119 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        include:
+          # manylinux builds
+          - os: ubuntu-latest
+            python: "cp39"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "cp310"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "cp311"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "cp312"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "cp313"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "cp314"
+            platform: manylinux_x86_64
+
+          # manylinux pypy builds
+          - os: ubuntu-latest
+            python: "pp39"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "pp310"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "pp311"
+            platform: manylinux_x86_64
+
+          # MacOS builds - intel
+          - os: macos-13
+            python: "cp39"
+            platform: macosx_x86_64
+          - os: macos-13
+            python: "cp310"
+            platform: macosx_x86_64
+          - os: macos-13
+            python: "cp311"
+            platform: macosx_x86_64
+          - os: macos-13
+            python: "cp312"
+            platform: macosx_x86_64
+          - os: macos-13
+            python: "cp313"
+            platform: macosx_x86_64
+          - os: macos-13
+            python: "cp314"
+            platform: macosx_x86_64
+
+          # MacOS PyPy builds
+          - os: macos-13
+            python: "pp39"
+            platform: macosx_x86_64
+          - os: macos-13
+            python: "pp310"
+            platform: macosx_x86_64
+          - os: macos-13
+            python: "pp311"
+            platform: macosx_x86_64
+
+          # MacOS arm64
+          - os: macos-14
+            python: "cp39"
+            platform: macosx_arm64
+          - os: macos-14
+            python: "cp310"
+            platform: macosx_arm64
+          - os: macos-14
+            python: "cp311"
+            platform: macosx_arm64
+          - os: macos-14
+            python: "cp312"
+            platform: macosx_arm64
+          - os: macos-14
+            python: "cp313"
+            platform: macosx_arm64
+          - os: macos-14
+            python: "cp314"
+            platform: macosx_arm64
+
+          # Windows builds
+          - os: windows-latest
+            python: "cp39"
+            platform: win_amd64
+          - os: windows-latest
+            python: "cp310"
+            platform: win_amd64
+          - os: windows-latest
+            python: "cp311"
+            platform: win_amd64
+          - os: windows-latest
+            python: "cp312"
+            platform: win_amd64
+          - os: windows-latest
+            python: "cp313"
+            platform: win_amd64
+          - os: windows-latest
+            python: "cp314"
+            platform: win_amd64
+
+          # Windows PyPy builds
+          - os: windows-latest
+            python: "pp39"
+            platform: win_amd64
+          - os: windows-latest
+            python: "pp310"
+            platform: win_amd64
+          - os: windows-latest
+            python: "pp311"
+            platform: win_amd64
 
     steps:
       - name: Checkout xcsf

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,7 +3,11 @@
 
 name: Wheel builder
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  release:
+    types:
+    - published
 
 jobs:
   build_wheels:
@@ -153,7 +157,7 @@ jobs:
 
   upload:
     runs-on: ubuntu-latest
-    # if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
     needs: [build_wheels, build_sdist]
     environment:
       name: pypi

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -140,9 +140,6 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install libomp
-          OPENMP_PREFIX=$(brew --prefix)/opt/libomp
-          echo "OpenMP_ROOT=$OPENMP_PREFIX" >> $GITHUB_ENV
-          echo "LDFLAGS=$LDFLAGS -L$OPENMP_PREFIX/lib" >> $GITHUB_ENV
           if [[ "${{ matrix.os }}" == "macos-13" ]]; then
             echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
           elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
@@ -152,6 +149,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.2
         env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,98 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # manylinux builds
-          - os: ubuntu-20.04
-            python: "cp39"
-            platform: manylinux_x86_64
-          - os: ubuntu-20.04
-            python: "cp310"
-            platform: manylinux_x86_64
-          - os: ubuntu-20.04
-            python: "cp311"
-            platform: manylinux_x86_64
-          - os: ubuntu-20.04
-            python: "cp312"
-            platform: manylinux_x86_64
-          - os: ubuntu-20.04
-            python: "cp313"
-            platform: manylinux_x86_64
-
-          # manylinux pypy builds
-          - os: ubuntu-20.04
-            python: "pp39"
-            platform: manylinux_x86_64
-          - os: ubuntu-20.04
-            python: "pp310"
-            platform: manylinux_x86_64
-
-          # MacOS builds - intel
-          - os: macos-12
-            python: "cp39"
-            platform: macosx_x86_64
-          - os: macos-12
-            python: "cp310"
-            platform: macosx_x86_64
-          - os: macos-12
-            python: "cp311"
-            platform: macosx_x86_64
-          - os: macos-12
-            python: "cp312"
-            platform: macosx_x86_64
-          - os: macos-12
-            python: "cp313"
-            platform: macosx_x86_64
-
-          # MacOS PyPy builds
-          - os: macos-12
-            python: "pp39"
-            platform: macosx_x86_64
-          - os: macos-12
-            python: "pp310"
-            platform: macosx_x86_64
-
-          # MacOS arm64
-          - os: macos-14
-            python: "cp39"
-            platform: macosx_arm64
-          - os: macos-14
-            python: "cp310"
-            platform: macosx_arm64
-          - os: macos-14
-            python: "cp311"
-            platform: macosx_arm64
-          - os: macos-14
-            python: "cp312"
-            platform: macosx_arm64
-          - os: macos-14
-            python: "cp313"
-            platform: macosx_arm64
-
-          # Windows builds
-          - os: windows-2019
-            python: "cp39"
-            platform: win_amd64
-          - os: windows-2019
-            python: "cp310"
-            platform: win_amd64
-          - os: windows-2019
-            python: "cp311"
-            platform: win_amd64
-          - os: windows-2019
-            python: "cp312"
-            platform: win_amd64
-          - os: windows-2019
-            python: "cp313"
-            platform: win_amd64
-
-          # Windows PyPy builds
-          - os: windows-2019
-            python: "pp39"
-            platform: win_amd64
-          - os: windows-2019
-            python: "pp310"
-            platform: win_amd64
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
 
     steps:
       - name: Checkout xcsf
@@ -115,11 +24,15 @@ jobs:
         with:
           submodules: true
 
-      - name: Set MACOSX_DEPLOYMENT_TARGET
+      - name: macOS Configuration
         if: runner.os == 'macOS'
         run: |
-          if [[ "${{ matrix.os }}" == "macos-12" ]]; then
-            echo "MACOSX_DEPLOYMENT_TARGET=12.0" >> $GITHUB_ENV
+          brew install libomp
+          OPENMP_PREFIX=$(brew --prefix)/opt/libomp
+          echo "OpenMP_ROOT=$OPENMP_PREFIX" >> $GITHUB_ENV
+          echo "LDFLAGS=$LDFLAGS -L$OPENMP_PREFIX/lib" >> $GITHUB_ENV
+          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+            echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
           elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
             echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
           fi
@@ -127,8 +40,6 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.2
         env:
-          CIBW_BEFORE_ALL_MACOS: CC=gcc-12 CXX=g++-12
-          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,17 +37,6 @@ jobs:
             python: "cp314"
             platform: manylinux_x86_64
 
-          # manylinux pypy builds
-          - os: ubuntu-latest
-            python: "pp39"
-            platform: manylinux_x86_64
-          - os: ubuntu-latest
-            python: "pp310"
-            platform: manylinux_x86_64
-          - os: ubuntu-latest
-            python: "pp311"
-            platform: manylinux_x86_64
-
           # MacOS builds - intel
           - os: macos-13
             python: "cp39"
@@ -66,17 +55,6 @@ jobs:
             platform: macosx_x86_64
           - os: macos-13
             python: "cp314"
-            platform: macosx_x86_64
-
-          # MacOS PyPy builds
-          - os: macos-13
-            python: "pp39"
-            platform: macosx_x86_64
-          - os: macos-13
-            python: "pp310"
-            platform: macosx_x86_64
-          - os: macos-13
-            python: "pp311"
             platform: macosx_x86_64
 
           # MacOS arm64
@@ -117,17 +95,6 @@ jobs:
             platform: win_amd64
           - os: windows-latest
             python: "cp314"
-            platform: win_amd64
-
-          # Windows PyPy builds
-          - os: windows-latest
-            python: "pp39"
-            platform: win_amd64
-          - os: windows-latest
-            python: "pp310"
-            platform: win_amd64
-          - os: windows-latest
-            python: "pp311"
             platform: win_amd64
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes:
 *   Reduce `max_trials` in Python tests for speed ([#206](https://github.com/xcsf-dev/xcsf/pull/206))
 *   Update Python packaging: move `setup.cfg` metadata to `pyproject.toml` ([#207](https://github.com/xcsf-dev/xcsf/pull/207))
 *   Fix macOS building with AppleClang ([#210](https://github.com/xcsf-dev/xcsf/pull/210))
+*   Add support for Python 3.14 ([#211](https://github.com/xcsf-dev/xcsf/pull/211))
 
 ## Version 1.4.7 (Aug 19, 2024)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
 include README.md LICENSE.md
 graft lib/pybind11/include
 graft lib/pybind11/tools
-graft lib/dSFMT
+include lib/dSFMT/*.h
+exclude lib/dSFMT/jump/*
 graft lib/cJSON
 graft xcsf
 global-include CMakeLists.txt *.cmake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.4.7"
 description = "XCSF learning classifier system: rule-based evolutionary machine learning"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "GPL-3.0"}
+license = "GPL-3.0-or-later"
 maintainers = [
     {name = "Richard Preen", email = "rpreen@gmail.com"}
 ]
@@ -32,7 +32,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: C",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,6 @@ class CMakeBuild(build_ext):
         cmake_args = [
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             "-DCMAKE_BUILD_TYPE=Release",
-            "-DCMAKE_C_COMPILER=gcc",
-            "-DCMAKE_CXX_COMPILER=g++",
             "-DXCSF_MAIN=OFF",
             "-DXCSF_PYLIB=ON",
             "-DENABLE_DOXYGEN=OFF",

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,6 @@ class CMakeBuild(build_ext):
         build_args = [ "--config", "Release" ]
 
         if platform.system() == "Darwin":
-            cmake_args += ["-DCMAKE_C_COMPILER=gcc-12"]  # Force GCC for CI
-            cmake_args += ["-DCMAKE_CXX_COMPILER=g++-12"]
             openmp_root = self._get_openmp_root()
             if openmp_root:
                 cmake_args += ["-DOpenMP_ROOT=" + openmp_root]

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ class CMakeBuild(build_ext):
             extdir += os.path.sep
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
+
         cmake_args = [
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             "-DCMAKE_BUILD_TYPE=Release",
@@ -68,10 +69,7 @@ class CMakeBuild(build_ext):
             "-DENABLE_DOXYGEN=OFF",
             "-DNATIVE_OPT=OFF",
         ]
-        build_args = [
-            "--config",
-            "Release",
-        ]
+        build_args = [ "--config", "Release" ]
 
         if platform.system() == "Darwin":
             openmp_root = self._get_openmp_root()
@@ -81,11 +79,14 @@ class CMakeBuild(build_ext):
                     f" -L{os.path.join(openmp_root, 'lib')}"
 
         if platform.system() == "Windows":
+            cmake_args += ["-DCMAKE_C_COMPILER=gcc"]
+            cmake_args += ["-DCMAKE_CXX_COMPILER=g++"]
             cmake_args += ["-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE=" + extdir]
             cmake_args += ["-GMinGW Makefiles"]
         else:
             cmake_args += ["-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir]
             build_args += ["-j4"]
+
         subprocess.check_call(
             ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp
         )

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ class CMakeBuild(build_ext):
             openmp_root = self._get_openmp_root()
             if openmp_root:
                 cmake_args += ["-DOpenMP_ROOT=" + openmp_root]
-                os.environ["LDFLAGS"] = os.environ.get("LDFLAGS", "") + f" -L{os.path.join(openmp_root, 'lib')}"
+                os.environ["LDFLAGS"] = os.environ.get("LDFLAGS", "") + \
+                    f" -L{os.path.join(openmp_root, 'lib')}"
 
         if platform.system() == "Windows":
             cmake_args += ["-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE=" + extdir]

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,8 @@ class CMakeBuild(build_ext):
         build_args = [ "--config", "Release" ]
 
         if platform.system() == "Darwin":
+            cmake_args += ["-DCMAKE_C_COMPILER=gcc-12"]  # Force GCC for CI
+            cmake_args += ["-DCMAKE_CXX_COMPILER=g++-12"]
             openmp_root = self._get_openmp_root()
             if openmp_root:
                 cmake_args += ["-DOpenMP_ROOT=" + openmp_root]

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,21 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     """Builds CMake extension."""
 
+    def _get_openmp_root(self):
+        """Get OpenMP root path on macOS."""
+        if platform.system() == "Darwin":
+            try:  # Try Homebrew first
+                return subprocess.check_output(
+                    ["brew", "--prefix", "libomp"], text=True
+                ).strip()
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                # Try common system paths
+                for path in ["/usr/local", "/opt/homebrew"]:
+                    if os.path.exists(f"{path}/lib/libomp.dylib"):
+                        return path
+        return None
+
+
     def build_extension(self, ext):
         self.announce("Configuring CMake project", level=3)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
@@ -59,9 +74,13 @@ class CMakeBuild(build_ext):
             "--config",
             "Release",
         ]
-        if platform.system() == "Darwin":  # set to force CI to use GCC
-            cmake_args[2] = "-DCMAKE_C_COMPILER=gcc-12"
-            cmake_args[3] = "-DCMAKE_CXX_COMPILER=g++-12"
+
+        if platform.system() == "Darwin":
+            openmp_root = self._get_openmp_root()
+            if openmp_root:
+                cmake_args += ["-DOpenMP_ROOT=" + openmp_root]
+                os.environ["LDFLAGS"] = os.environ.get("LDFLAGS", "") + f" -L{os.path.join(openmp_root, 'lib')}"
+
         if platform.system() == "Windows":
             cmake_args += ["-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE=" + extdir]
             cmake_args += ["-GMinGW Makefiles"]


### PR DESCRIPTION
* Run automatically on release generation and publish to PyPI.
* Run on manual workflow dispatch will build wheels but not publish.
* Build macOS wheels with AppleClang.
* Add Python 3.14 wheels.